### PR TITLE
chore: add try catch to deleting image cache

### DIFF
--- a/src/cache.spec.ts
+++ b/src/cache.spec.ts
@@ -32,6 +32,7 @@ const mocks = vi.hoisted(() => ({
   fsStatSync: vi.fn(),
   fsWriteFile: vi.fn(),
   fsMkdir: vi.fn(),
+  fsRm: vi.fn(),
 }));
 
 vi.mock('fs/promises', async () => {
@@ -41,6 +42,7 @@ vi.mock('fs/promises', async () => {
     readdir: mocks.fsReaddir,
     writeFile: mocks.fsWriteFile,
     mkdir: mocks.fsMkdir,
+    rm: mocks.fsRm,
   };
 });
 
@@ -317,5 +319,23 @@ describe('cache', () => {
     vi.spyOn(cache, 'limitSize').mockResolvedValue();
     await cache.save({ Id: 'sha256:1' } as ImageInfo, { layers: [] });
     expect(mocks.fsWriteFile).not.toHaveBeenCalled();
+  });
+
+  it('delete logs a warning in console if there is an error that is not ENOENT', async () => {
+    const err: Error & { code?: string } = new Error('error deleting image cache');
+    err.code = 'ERR1';
+    mocks.fsRm.mockRejectedValue(err);
+    await cache.deleteCacheFile('/some/file');
+    expect(mocks.fsRm).toHaveBeenCalledWith('/path/to/extension/cache/v1/some/file');
+    expect(mocks.consoleWarnMock).toHaveBeenCalledWith(`error deleting cache file /some/file`, err);
+  });
+
+  it('delete does not log a warning in console if there is an ENOENT error', async () => {
+    const err: Error & { code?: string } = new Error('error deleting image cache');
+    err.code = 'ENOENT';
+    mocks.fsRm.mockRejectedValue(err);
+    await cache.deleteCacheFile('/some/file');
+    expect(mocks.fsRm).toHaveBeenCalledWith('/path/to/extension/cache/v1/some/file');
+    expect(mocks.consoleWarnMock).not.toHaveBeenCalled();
   });
 });

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -108,7 +108,13 @@ export class Cache {
   }
 
   public async deleteCacheFile(filename: string): Promise<void> {
-    await rm(path.join(this.getRootDir(), filename));
+    try {
+      await rm(path.join(this.getRootDir(), filename));
+    } catch (error: unknown) {
+      if (this.isErrorWithCode(error) && error.code !== 'ENOENT') {
+        console.warn(`error deleting cache file ${filename}`, error);
+      }
+    }
   }
 
   private getRootDir(): string {


### PR DESCRIPTION
### What does this PR do?
This PR adds a try catch block to the `deleteCacheFile` method so that in case an image that doesn't have a cache file is deleted, the error is caught. 
The ENOENT error is ignored while any other error code is logged as a warning in the console.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/extension-layers-explorer/issues/104

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature