### PR TITLE
fix: resolve CVE-2026-53550 in js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   "pnpm": {
     "overrides": {
       "brace-expansion@>=5.0.0 <5.0.6": ">=5.0.6",
-      "minimatch@>=9.0.0 <9.0.7": "9.0.7"
+      "minimatch@>=9.0.0 <9.0.7": "9.0.7",
+      "js-yaml": ">=4.2.0"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   brace-expansion@>=5.0.0 <5.0.6: '>=5.0.6'
   minimatch@>=9.0.0 <9.0.7: 9.0.7
+  js-yaml: '>=4.2.0'
 
 importers:
 
@@ -1274,8 +1275,8 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -2043,7 +2044,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2975,7 +2976,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -3336,7 +3337,7 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability CVE-2026-53550 in `js-yaml`.

**Advisory**: JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases
**Vulnerable versions**: <=4.1.1
**Patched versions**: >=4.2.0
**Advisory URL**: https://github.com/advisories/GHSA-h67p-54hq-rp68

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-53550: _JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-53550 is no longer reported