### PR TITLE
fix: resolve CVE-2026-13149 in brace-expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "pnpm": {
     "overrides": {
       "brace-expansion@>=5.0.0 <5.0.6": ">=5.0.6",
+      "brace-expansion@<1.1.16": "1.1.16",
       "minimatch@>=9.0.0 <9.0.7": "9.0.7",
       "js-yaml": ">=4.2.0"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   brace-expansion@>=5.0.0 <5.0.6: '>=5.0.6'
+  brace-expansion@<1.1.16: 1.1.16
   minimatch@>=9.0.0 <9.0.7: 9.0.7
   js-yaml: '>=4.2.0'
 
@@ -669,8 +670,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
   brace-expansion@5.0.7:
     resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
@@ -2635,7 +2636,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -3492,7 +3493,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.16
 
   minimatch@9.0.7:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-13149 in `brace-expansion`.

**Advisory**: brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups
**Vulnerable versions**: <1.1.16
**Patched versions**: >=1.1.16
**Advisory URL**: https://github.com/advisories/GHSA-3jxr-9vmj-r5cp

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-13149: _brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-13149 is no longer reported