### PR TITLE
fix: resolve CVE-2026-59869 in js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
       "brace-expansion@>=5.0.0 <5.0.6": ">=5.0.6",
       "brace-expansion@<1.1.16": "1.1.16",
       "minimatch@>=9.0.0 <9.0.7": "9.0.7",
-      "js-yaml": ">=4.2.0"
+      "js-yaml": ">=4.3.0 <5.0.0"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   brace-expansion@>=5.0.0 <5.0.6: '>=5.0.6'
   brace-expansion@<1.1.16: 1.1.16
   minimatch@>=9.0.0 <9.0.7: 9.0.7
-  js-yaml: '>=4.2.0'
+  js-yaml: '>=4.3.0 <5.0.0'
 
 importers:
 
@@ -1294,8 +1294,8 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -2078,7 +2078,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -3023,7 +3023,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -3384,7 +3384,7 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-59869 in `js-yaml`.

**Advisory**: js-yaml: YAML merge-key chains can force quadratic CPU consumption
**Vulnerable versions**: >=4.0.0 <4.3.0
**Patched versions**: >=4.3.0
**Advisory URL**: https://github.com/advisories/GHSA-52cp-r559-cp3m

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-59869: _js-yaml: YAML merge-key chains can force quadratic CPU consumption_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-59869 is no longer reported